### PR TITLE
Fix build script for missing .env

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,12 @@ set -e
 
 echo "Preparing build..."
 
-# Load env vars from .env
-set -o allexport
-source .env
-set +o allexport
+# Load env vars from .env if present
+if [ -f .env ]; then
+    set -o allexport
+    source .env
+    set +o allexport
+fi
 
 mkdir -p dist
 


### PR DESCRIPTION
## Summary
- handle missing `.env` gracefully in `build.sh`

## Testing
- `bash build.sh`